### PR TITLE
Support S3 Backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Demo Metadata
             }
         }
     },
-    'backup_folders': {
+    'backup_folders': [
         '/etc',
-    },
+    ],
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Restic Bundle
 -------------
 
-This Bundle Downloads and Configures Restic (https://restic.net/). 
+This Bundle Downloads and Configures Restic (https://restic.net/).
 It will pin your Backups server host key.
 
 Needed Plugins
@@ -22,6 +22,7 @@ Demo Metadata
 'restic': {
     'backup_hosts': {
         'backup.mydomain.net': {
+            #'repository_type': 'sftp',
             'username': 'myBackupUser',
             'port': 12345,
             'hostkey': 'ecdsa-sha2-nistp256 ...',
@@ -33,7 +34,24 @@ Demo Metadata
                 'monthly': 5,
                 'yearly': 1,
             }
-        }
+        },
+        'minio.example.org': {
+            'repository_type': 'minio',
+            'address': 'https://localhost:9000',
+            #'bucket_name': node.name,
+            'environment_vars': {
+                'AWS_ACCESS_KEY_ID': 'foobar',
+                'AWS_SECRET_ACCESS_KEY': vault.decrypt('...').value,
+            },
+            'keep': {
+                'last': 1,
+                'hourly': 3,
+                'daily': 5,
+                'weekly': 2,
+                'monthly': 5,
+                'yearly': 1,
+            }
+        },
     },
     'backup_folders': [
         '/etc',

--- a/files/cron_daily.sh
+++ b/files/cron_daily.sh
@@ -2,6 +2,7 @@
 
 export RESTIC_PASSWORD_FILE=/etc/restic/password_${backup_host}
 export RESTIC_REPOSITORY=${restic_repository}
+. /etc/restic/env_${backup_host}
 
 if [ -f ${LOCK_FILE} ]; then
     exit 0

--- a/files/cron_daily.sh
+++ b/files/cron_daily.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export RESTIC_PASSWORD_FILE=/etc/restic/password_${backup_host}
-export RESTIC_REPOSITORY=sftp://${backup_host}/${node_name}
+export RESTIC_REPOSITORY=${restic_repository}
 
 if [ -f ${LOCK_FILE} ]; then
     exit 0

--- a/files/cron_daily.sh
+++ b/files/cron_daily.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-export RESTIC_PASSWORD_FILE=/etc/restic/password_${backup_host}
-export RESTIC_REPOSITORY=${restic_repository}
 . /etc/restic/env_${backup_host}
 
 if [ -f ${LOCK_FILE} ]; then

--- a/files/cron_hourly.sh
+++ b/files/cron_hourly.sh
@@ -2,6 +2,7 @@
 
 export RESTIC_PASSWORD_FILE=/etc/restic/password_${backup_host}
 export RESTIC_REPOSITORY=${restic_repository}
+. /etc/restic/env_${backup_host}
 
 if [ -f ${LOCK_FILE} ]; then
     exit 0

--- a/files/cron_hourly.sh
+++ b/files/cron_hourly.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export RESTIC_PASSWORD_FILE=/etc/restic/password_${backup_host}
-export RESTIC_REPOSITORY=sftp://${backup_host}/${node_name}
+export RESTIC_REPOSITORY=${restic_repository}
 
 if [ -f ${LOCK_FILE} ]; then
     exit 0

--- a/files/cron_hourly.sh
+++ b/files/cron_hourly.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-export RESTIC_PASSWORD_FILE=/etc/restic/password_${backup_host}
-export RESTIC_REPOSITORY=${restic_repository}
 . /etc/restic/env_${backup_host}
 
 if [ -f ${LOCK_FILE} ]; then

--- a/files/env_backup_host
+++ b/files/env_backup_host
@@ -1,0 +1,3 @@
+% for key,value in environment_vars.items():
+export ${key}=${value}
+% endfor

--- a/files/env_backup_host
+++ b/files/env_backup_host
@@ -1,3 +1,5 @@
+export RESTIC_PASSWORD_FILE=/etc/restic/password_${backup_host}
+export RESTIC_REPOSITORY=${repository_url}
 % for key,value in environment_vars.items():
 export ${key}=${value}
 % endfor

--- a/items.py
+++ b/items.py
@@ -157,6 +157,8 @@ for backup_host, backup_host_config in node.metadata.get('restic', {}).get('back
     files[f'/etc/restic/env_{backup_host}'] = {
         'content_type': "mako",
         'context': {
+            'repository_url': repository_url,
+            'backup_host': backup_host,
             'environment_vars': backup_host_config.get('environment_vars', []),
         },
         'source': 'env_backup_host',
@@ -170,7 +172,7 @@ for backup_host, backup_host_config in node.metadata.get('restic', {}).get('back
                    f'--password-file /etc/restic/password_{backup_host} '
                    f'-r {repository_url} '
                    'init',
-        'unless': f'/opt/restic/restic -r {repository_url} cat config',
+        'unless': f'. /etc/restic/env_{backup_host} && /opt/restic/restic -r {repository_url} cat config',
         'needs': [
             f'download:/opt/restic/restic_{RESTIC_VERSION}.bz2',
             f'tag:prepare_restic_backup_{backup_host}',

--- a/items.py
+++ b/items.py
@@ -186,7 +186,6 @@ for backup_host, backup_host_config in node.metadata.get('restic', {}).get('back
         'context': {
             'restic_repository': repository_url,
             'backup_host': backup_host,
-            'node_name': node.name,
             'keep': backup_host_config.get('keep', {}),
             'pre_commands': node.metadata.get('restic', {}).get('pre_commands', []),
             'post_commands': node.metadata.get('restic', {}).get('post_commands', []),
@@ -208,7 +207,6 @@ for backup_host, backup_host_config in node.metadata.get('restic', {}).get('back
         'context': {
             'restic_repository': repository_url,
             'backup_host': backup_host,
-            'node_name': node.name,
             'keep': backup_host_config.get('keep', {}),
             'LOCK_FILE': f'/tmp/restic_{backup_host}.lock',
         },

--- a/items.py
+++ b/items.py
@@ -4,8 +4,8 @@ import socket
 
 global node, repo
 
-RESTIC_VERSION = '0.16.0'
-RESTIC_SHA256 = '492387572bb2c4de904fa400636e05492e7200b331335743d46f2f2874150162'
+RESTIC_VERSION = node.metadata.get('restic').get('version')
+RESTIC_SHA256 = node.metadata.get('restic').get('checksum_sha256')
 
 
 directories = {

--- a/items.py
+++ b/items.py
@@ -56,89 +56,105 @@ files = {
 
 
 for backup_host, backup_host_config in node.metadata.get('restic', {}).get('backup_hosts', {}).items():
-    try:
-        backup_node = repo.get_node(backup_host)
-        backup_host = backup_node.hostname
-        backup_host_ips = backup_node.metadata.get('interfaces', {}) \
-            .get(backup_node.metadata.get('main_interface', 'eth0'), {}) \
-            .get('ip_addresses', [])
+    if backup_host_config.get('backend_type', 'sftp') == 'sftp':
+        try:
+            backup_node = repo.get_node(backup_host)
+            backup_host = backup_node.hostname
+            backup_host_ips = backup_node.metadata.get('interfaces', {}) \
+                .get(backup_node.metadata.get('main_interface', 'eth0'), {}) \
+                .get('ip_addresses', [])
 
-        host_key = backup_node.metadata['openssh']['hostkey']  # This will break!!, if it is not set!
-    except NoSuchNode:
-        # TODO: make work without internet
-        backup_host_ips = [socket.gethostbyname(backup_host), ]
-        host_key = backup_host_config.get('hostkey')  # This should break, if it is not set!
+            host_key = backup_node.metadata['openssh']['hostkey']  # This will break!!, if it is not set!
+        except NoSuchNode:
+            # TODO: make work without internet
+            backup_host_ips = [socket.gethostbyname(backup_host), ]
+            host_key = backup_host_config.get('hostkey')  # This should break, if it is not set!
 
-    identity_file = f"~/.ssh/{backup_host}"
-    port = backup_host_config.get('port', 22)
+        identity_file = f"~/.ssh/{backup_host}"
+        port = backup_host_config.get('port', 22)
 
-    actions[f'create_ssh_key_{backup_host}'] = {
-        'command': 'ssh-keygen -t ed25519 -f ~/.ssh/{host_name} -C {comment} -N ""'.format(
-            host_name=backup_host,
-            comment=quote(node.name)
-        ),
-        'unless': f'test -f ~/.ssh/{backup_host}',
-    }
-    # node.download(f'/root/.ssh/{backup_host}.pub', 'test123')
-    actions[f'add_ssh_config_{backup_host}'] = {
-        'command': 'echo "Host {host_name}\\n'
-                   'user {backup_user}\\n'
-                   'identityfile {identity_file}\\n'
-                   'port {port}"'
-                   ' >> ~/.ssh/config'.format(
-                        host_name=backup_host,
-                        backup_user=backup_host_config.get('username', 'scoutnetbackup'),
-                        identity_file=identity_file,
-                        port=port,
-                   ),
-        'unless': f'grep -q \'{backup_host}\' ~/.ssh/config',
-    }
+        actions[f'create_ssh_key_{backup_host}'] = {
+            'command': 'ssh-keygen -t ed25519 -f ~/.ssh/{host_name} -C {comment} -N ""'.format(
+                host_name=backup_host,
+                comment=quote(node.name)
+            ),
+            'unless': f'test -f ~/.ssh/{backup_host}',
+        }
+        # node.download(f'/root/.ssh/{backup_host}.pub', 'test123')
+        actions[f'add_ssh_config_{backup_host}'] = {
+            'command': 'echo "Host {host_name}\\n'
+                       'user {backup_user}\\n'
+                       'identityfile {identity_file}\\n'
+                       'port {port}"'
+                       ' >> ~/.ssh/config'.format(
+                            host_name=backup_host,
+                            backup_user=backup_host_config.get('username', 'scoutnetbackup'),
+                            identity_file=identity_file,
+                            port=port,
+                       ),
+            'unless': f'grep -q \'{backup_host}\' ~/.ssh/config',
+        }
 
-    # add hostkey for hostname in known hosts file
-    ssh_known_hosts_host_name = backup_host
-    if port != 22:
-        ssh_known_hosts_host_name = f"[{backup_host}]:{port}"
-
-    actions[f'add_known_host_{backup_host}'] = {
-        'command': 'echo {host_name} {host_key} >> ~/.ssh/known_hosts'.format(
-            host_name=quote(ssh_known_hosts_host_name),
-            host_key=quote(host_key)
-        ),
-        'unless': 'grep -q {host_name} ~/.ssh/known_hosts'.format(
-            host_name=quote(ssh_known_hosts_host_name).replace('[', '\\[').replace(']', '\\]')
-        ),
-    }
-
-    # add hostkey for ip in known hosts file
-    for backup_host_ip in backup_host_ips:
-        ssh_known_hosts_host_ip = backup_host_ip
+        # add hostkey for hostname in known hosts file
+        ssh_known_hosts_host_name = backup_host
         if port != 22:
-            ssh_known_hosts_host_ip = f"[{backup_host_ip}]:{port}"
+            ssh_known_hosts_host_name = f"[{backup_host}]:{port}"
 
-        actions[f'add_known_host_{backup_host_ip}'] = {
-            'command': 'echo {host_ip} {host_key} >> ~/.ssh/known_hosts'.format(
-                host_ip=quote(ssh_known_hosts_host_ip),
+        actions[f'add_known_host_{backup_host}'] = {
+            'command': 'echo {host_name} {host_key} >> ~/.ssh/known_hosts'.format(
+                host_name=quote(ssh_known_hosts_host_name),
                 host_key=quote(host_key)
             ),
-            'unless': 'grep -q {host_ip} ~/.ssh/known_hosts'.format(
-                host_ip=quote(ssh_known_hosts_host_ip).replace('[', '\\[').replace(']', '\\]')
+            'unless': 'grep -q {host_name} ~/.ssh/known_hosts'.format(
+                host_name=quote(ssh_known_hosts_host_name).replace('[', '\\[').replace(']', '\\]')
             ),
         }
 
-    actions[f'print_ssh_key_{backup_host}'] = {
-        'command': 'echo "please register this ssh key on {host_name}:" && cat {identity_file}.pub && exit 255'.format(
-            host_name=backup_host,
-            identity_file=identity_file
-        ),
-        # we only allow rsync, sftp and scp
-        'unless': 'ssh {host_name} rsync --server --version || false'.format(host_name=backup_host),
-        'needs': [
-            'action:create_ssh_key_{host_name}'.format(host_name=backup_host),
-            'action:add_ssh_config_{host_name}'.format(host_name=backup_host),
-            'action:add_known_host_{host_name}'.format(host_name=backup_host),
-            # 'action:add_known_host_{host_ip}'.format(host_ip=backup_host_ip),
-        ]
-    }
+        # add hostkey for ip in known hosts file
+        for backup_host_ip in backup_host_ips:
+            ssh_known_hosts_host_ip = backup_host_ip
+            if port != 22:
+                ssh_known_hosts_host_ip = f"[{backup_host_ip}]:{port}"
+
+            actions[f'add_known_host_{backup_host_ip}'] = {
+                'command': 'echo {host_ip} {host_key} >> ~/.ssh/known_hosts'.format(
+                    host_ip=quote(ssh_known_hosts_host_ip),
+                    host_key=quote(host_key)
+                ),
+                'unless': 'grep -q {host_ip} ~/.ssh/known_hosts'.format(
+                    host_ip=quote(ssh_known_hosts_host_ip).replace('[', '\\[').replace(']', '\\]')
+                ),
+            }
+
+        actions[f'print_ssh_key_{backup_host}'] = {
+            'command': 'echo "please register this ssh key on {host_name}:" && cat {identity_file}.pub && exit 255'.format(
+                host_name=backup_host,
+                identity_file=identity_file
+            ),
+            # we only allow rsync, sftp and scp
+            'unless': 'ssh {host_name} rsync --server --version || false'.format(host_name=backup_host),
+            'needs': [
+                'action:create_ssh_key_{host_name}'.format(host_name=backup_host),
+                'action:add_ssh_config_{host_name}'.format(host_name=backup_host),
+                'action:add_known_host_{host_name}'.format(host_name=backup_host),
+                # 'action:add_known_host_{host_ip}'.format(host_ip=backup_host_ip),
+            ]
+        }
+
+        backend_url = f'sftp://{backup_host}/{node.name}'
+
+        actions[f'check_init_restic_{backup_host}_sftp'] = {
+            'command': 'echo "dummy command"',
+            # we only allow rsync, sftp and scp
+            # try to get config file, if it is not present, we will create the repository
+            'unless': f'rsync -n {backup_host}:{node.name}/config /tmp || false',
+            'triggers': [
+                f'action:init_restic_{backup_host}',
+            ]
+        }
+
+    if backup_host_config.get('backend_type') == 's3':
+        pass
 
     files[f'/etc/restic/password_{backup_host}'] = {
         'content': repo.vault.password_for(f"restic_password_{backup_host}_{node.name}").value,
@@ -150,14 +166,9 @@ for backup_host, backup_host_config in node.metadata.get('restic', {}).get('back
     actions[f'init_restic_{backup_host}'] = {
         'command': '/opt/restic/restic '
                    '--password-file /etc/restic/password_{host_name} '
-                   '-r sftp://{host_name}/{node_name} '
-                   'init'.format(
-                        host_name=backup_host,
-                        node_name=node.name
-                   ),
-        # we only allow rsync, sftp and scp
-        # try to get config file, if it is not present, we will create the repository
-        'unless': f'rsync -n {backup_host}:{node.name}/config /tmp || false',
+                   f'-r {backend_url} '
+                   'init',
+        'triggered': True,
         'needs': [
             f'download:/opt/restic/restic_{RESTIC_VERSION}.bz2',
             f'action:print_ssh_key_{backup_host}',

--- a/metadata.py
+++ b/metadata.py
@@ -26,6 +26,10 @@ if node.has_bundle("apt"):
 def load_public_keys(metadata):
     backup_hosts = {}
     for backup_host, config in metadata.get('restic/backup_hosts', {}).items():
+        # Skip all none-sftp repositories
+        if config.get('repository_type', 'sftp') != 'sftp':
+            continue
+
         try:
             backup_node = repo.get_node(backup_host)
             backup_host = backup_node.hostname

--- a/metadata.py
+++ b/metadata.py
@@ -5,7 +5,12 @@ from bundlewrap.exceptions import NoSuchNode, RemoteException
 
 global metadata_reactor, node, repo
 
-defaults = {}
+defaults = {
+    'restic': {
+        'version': '0.16.4',
+        'checksum_sha256': '3d4d43c169a9e28ea76303b1e8b810f0dcede7478555fdaa8959971ad499e324',
+    }
+}
 
 if node.has_bundle("apt"):
     defaults['apt'] = {


### PR DESCRIPTION
Add support for S3 and MinIO repository backends.

Also used the recommended way to check if the repo is already initialized (https://restic.readthedocs.io/en/stable/075_scripting.html#check-if-a-repository-is-already-initialized), fixed few typos and make version & checksum configurable.